### PR TITLE
bump straight to v0.1.21

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.18
+current_version = 0.1.21
 commit = True
 tag = True
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqloxide"
-version = "0.1.18"
+version = "0.1.21"
 authors = ["Will Eaton <me@wseaton.com>"]
 edition = "2018"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sqloxide"
-version = "0.1.18"
+version = "0.1.21"
 repository = "https://github.com/wseaton/sqloxide"
 license = "MIT"
 description = "Python bindings for sqlparser-rs"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ package_data = \
 
 setup_kwargs = {
     'name': 'sqloxide',
-    'version': '0.1.18',
+    'version': '0.1.21',
     'description': 'Python bindings for sqlparser-rs',
     'long_description': open('readme.md').read(),
     'long_description_content_type': 'text/markdown',


### PR DESCRIPTION
Since `sqlparser-rs` has been updating frequently, we are going to bump straight to v0.1.21, which doesn't technically break semver. I am open to the idea of providing backports for intermediate versions on request :slightly_smiling_face: 