### PR TITLE
Pin poetry-version to 1.3.2 in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Run image
         uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: 1.3.2
       - name: Install package deps
         run: | 
           poetry install


### PR DESCRIPTION
The GitHub Actions job `native-build` relies on poetry to create the `.so` file in the `sqloxide` directory in order for the `pytest` imports to succeed. However, after the [poetry 1.4.0 release](https://github.com/python-poetry/poetry/releases/tag/1.4.0), poetry was no longer creating this file, so the import from `.sqloxide` in `sqloxide/__init__.py` was failing.

We can avoid this issue by pinning `poetry-version` to `1.3.2` in `ci.yml`:
https://github.com/adavis444/sqloxide/actions/runs/4799551537