### PR TITLE
Upload .tar.gz source distribution with wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,9 +140,24 @@ jobs:
           name: wheels
           path: io/dist/*${{ matrix.tag }}_${{ matrix.arch }}.whl
 
+  source-build:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build source distribution
+        run: |
+          pip install -U setuptools wheel setuptools-rust
+          python setup.py sdist
+      - name: Archive source distribution
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist/*
+
   publish:
     runs-on: ubuntu-latest
-    needs: [manylinux-build, native-build]
+    needs: [manylinux-build, native-build, source-build]
     steps: 
 
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
As seen on https://pypi.org/project/sqloxide/#files, sqloxide does not have any source distributions uploaded to PyPI. This makes it impossible to use PyPI with sqloxide for a given os and architecture unless the necessary wheel has been built.

We can include this source distribute by creating the job `source-build` in `ci.yml`. A separate job is preferable here to prevent duplication and collisions from multiple matrix configurations.

By running `python setup.py sdist` we can generate `sqloxide-0.1.30.tar.gz` in `dist/`.