### PR TITLE
Enable wheels for python 3.11 on macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,6 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [macos-latest, windows-latest, ubuntu-latest]
-        exclude:
-          - os: macos-latest # no runners available yet
-            python-version: "3.11"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
Rebase of https://github.com/adavis444/sqloxide/pull/2

Wheels for python 3.11 on macos-latest had previously been excluded due to no available runners. Fortunately, that is now available, so the `exclude` can be removed from `ci.yml`.