### PR TITLE
V0.1.39 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.37
+current_version = 0.1.39
 commit = True
 tag = True
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,9 @@ jobs:
         with:
           poetry-version: 1.3.2
       - name: Install package deps
-        run: | 
+        run: |
           poetry install
-      
+
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -75,13 +75,13 @@ jobs:
         shell: bash
         env:
           DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
-          MACOSX_DEPLOYMENT_TARGET: '10.9'
+          MACOSX_DEPLOYMENT_TARGET: "10.9"
           ARCHFLAGS: -arch x86_64 -arch arm64
           PYO3_CROSS_LIB_DIR: /Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/lib
         run: poetry run python setup.py bdist_wheel && poetry install
 
       - name: Build Python package
-        if:  matrix.os != 'macos-latest'
+        if: matrix.os != 'macos-latest'
         run: poetry run python setup.py bdist_wheel && poetry install
 
       - name: pytest
@@ -108,13 +108,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {tag: manylinux2014, arch: x86_64}
-          - {tag: manylinux2014, arch: i686}
-          - {tag: manylinux2014, arch: aarch64}
-          # TODO: figure out a way to renable this, for now it's far too slow
+          - { tag: manylinux2014, arch: x86_64 }
+          - { tag: manylinux2014, arch: i686 }
+          # TODO: figure out a way to renable these, for now far too slow
           # to run in github actions (> 6hrs)
           # - {tag: manylinux2014, arch: ppc64le}
-
+          # - {tag: manylinux2014, arch: aarch64}
     runs-on: ubuntu-latest
     needs: lint
     steps:
@@ -159,10 +158,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [manylinux-build, native-build, source-build]
-    steps: 
-
+    steps:
       - uses: actions/download-artifact@v2
-        with: 
+        with:
           name: wheels
           path: dist/
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqloxide"
-version = "0.1.36"
+version = "0.1.39"
 authors = ["Will Eaton <me@wseaton.com>"]
 edition = "2018"
 
@@ -9,13 +9,13 @@ name = "sqloxide"
 crate-type = ["cdylib"]
 
 [dependencies]
-pythonize = "0.19"
+pythonize = "0.20"
 serde = "1.0.171"
 
 [dependencies.pyo3]
-version = "0.19.1"
+version = "0.20.0"
 features = ["extension-module"]
 
 [dependencies.sqlparser]
-version = "0.36.1"
+version = "0.39.0"
 features = ["serde", "visitor"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sqloxide"
-version = "0.1.37"
+version = "0.1.39"
 repository = "https://github.com/wseaton/sqloxide"
 license = "MIT"
 description = "Python bindings for sqlparser-rs"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ package_data = {"": ["*"]}
 
 setup_kwargs = {
     "name": "sqloxide",
-    "version": "0.1.37",
+    "version": "0.1.39",
     "description": "Python bindings for sqlparser-rs",
     "long_description": open("readme.md").read(),
     "long_description_content_type": "text/markdown",


### PR DESCRIPTION

Upstream Changelog since last release: https://github.com/sqlparser-rs/sqlparser-rs/blob/main/CHANGELOG.md#0390-2023-10-27

Also added `duckdb` to the list of imported dialects, it was realeased in `0.34.0` but missed!


## [0.39.0] 2023-10-27

### Added
* Support for `LATERAL FLATTEN` and similar (#1026) - Thanks @lustefaniak
* Support BigQuery struct, array and bytes , int64, `float64` datatypes (#1003) - Thanks @iffyio
* Support numbers as placeholders in Snowflake (e.g. `:1)` (#1001) - Thanks @yuval-illumex
* Support date 'key' when using semi structured data (#1023) @yuval-illumex
* Support IGNORE|RESPECT NULLs clause in window functions (#998) - Thanks @yuval-illumex
* Support for single-quoted identifiers (#1021) - Thanks @lovasoa
* Support multiple PARTITION statements in ALTER TABLE ADD statement (#1011) - Thanks @bitemyapp
* Support "with" identifiers surrounded by backticks in GenericDialect (#1010) - Thanks @bitemyapp
* Support INSERT IGNORE in MySql and GenericDialect (#1004) - Thanks @emin100
* Support SQLite `pragma` statement (#969) - Thanks @marhoily
* Support `position` as a column name (#1022) - Thanks @lustefaniak
* Support `FILTER` in Functions (for `OVER`) clause (#1007) - Thanks @lovasoa
* Support `SELECT * EXCEPT/REPLACE` syntax from ClickHouse (#1013) - Thanks @lustefaniak
* Support subquery as function arg w/o parens in Snowflake dialect (#996) - Thanks @jmhain
* Support `UNION DISTINCT BY NAME` syntax (#997) - Thanks @alexander-beedie
* Support mysql `RLIKE` and `REGEXP` binary operators (#1017) - Thanks @lovasoa
* Support bigquery `CAST AS x [STRING|DATE] FORMAT` syntax (#978) - Thanks @lustefaniak
* Support Snowflake/BigQuery `TRIM`. (#975) - Thanks @zdenal
* Support `CREATE [TEMPORARY|TEMP] VIEW [IF NOT EXISTS] `(#993) - Thanks @gabivlj
* Support for `CREATE VIEW … WITH NO SCHEMA BINDING` Redshift (#979) - Thanks @lustefaniak
* Support `UNPIVOT` and a fix for chained PIVOTs (#983) - @jmhain
* Support for `LIMIT BY` (#977) - Thanks @lustefaniak
* Support for mixed BigQuery table name quoting (#971) - Thanks @iffyio
* Support `DELETE` with `ORDER BY` and `LIMIT` (MySQL) (#992) - Thanks @ulrichsg
* Support `EXTRACT` for `DAYOFWEEK`, `DAYOFYEAR`, `ISOWEEK`, `TIME` (#980) - Thanks @lustefaniak
* Support `ATTACH DATABASE` (#989) - Thanks @lovasoa

### Fixed
* Fix handling of `/~%` in Snowflake stage name (#1009) - Thanks @lustefaniak
* Fix column `COLLATE` not displayed (#1012) - Thanks @lustefaniak
* Fix for clippy 1.73 (#995) - Thanks @alamb

### Changed
* Test to ensure `+ - * / %` binary operators work the same in all dialects (#1025)  - Thanks @lustefaniak
* Improve documentation on Parser::consume_token and friends (#994) - Thanks @alamb
* Test that regexp can be used as an identifier in postgres (#1018) - Thanks @lovasoa
* Add docstrings for Dialects, update README (#1016) - Thanks @alamb
* Add JumpWire to users in README (#990) - Thanks @hexedpackets
* Add tests for clickhouse: `tokenize == as Token::DoubleEq` (#981)- Thanks @lustefaniak

## [0.38.0] 2023-09-21

### Added

* Support `==`operator for Sqlite (#970) - Thanks @marhoily
* Support mysql `PARTITION` to table selection (#959) - Thanks  @chunshao90
* Support `UNNEST` as a table factor for PostgreSQL (#968) @hexedpackets
* Support MySQL `UNIQUE KEY` syntax (#962) - Thanks @artorias1024
* Support` `GROUP BY ALL` (#964) - @berkaysynnada
* Support multiple actions in one ALTER TABLE statement (#960) - Thanks @ForbesLindesay
* Add `--sqlite param` to CLI (#956) - Thanks @ddol

### Fixed
* Fix Rust 1.72 clippy lints (#957) - Thanks @alamb

### Changed
* Add missing token loc in parse err msg (#965) - Thanks @ding-young
* Change how `ANY` and `ALL` expressions are represented in AST (#963) - Thanks @SeanTroyUWO
* Show location info in parse errors (#958) - Thanks @MartinNowak
* Update release documentation (#954) - Thanks @alamb
* Break test and coverage test into separate jobs (#949) - Thanks @alamb
