### PR TITLE
Update build.yaml to support build wheels for python 3.7 and Upgrade to sqlparser-rs 0.56.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,17 +19,31 @@ jobs:
           maturin-version: latest
           command: build
           manylinux: auto
-          args: --release --sdist -i 3.8 3.9 3.10 3.11 3.12 3.13
+          args: --release --sdist -i 3.7 3.8 3.9 3.10 3.11 3.12 3.13
       - uses: actions/upload-artifact@v4
         with:
           name: linux-wheels-${{ matrix.target }}
           path: target/wheels/
 
   osx-wheels:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
+        include:
+          - os: macos-13
+            python-version: 3.7
+          - os: macos-latest
+            python-version: 3.8
+          - os: macos-latest
+            python-version: 3.9
+          - os: macos-latest
+            python-version: "3.10"
+          - os: macos-latest
+            python-version: "3.11"
+          - os: macos-latest
+            python-version: "3.12"
+          - os: macos-latest
+            python-version: "3.13"
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -39,7 +53,14 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Build wheels
+      - name: Build wheels for Python 3.7
+        if: matrix.python-version == '3.7'
+        run: |
+          rustup target add aarch64-apple-darwin
+          python3 -m pip install maturin
+          maturin build --release --target universal2-apple-darwin
+      - name: Build wheels for other Python versions
+        if: matrix.python-version != '3.7'
         run: |
           python3 -m pip install maturin
           maturin build --release
@@ -52,7 +73,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -91,12 +112,14 @@ jobs:
       - run: mv ./osx-3.10-wheel/* wheels
       - run: mv ./osx-3.9-wheel/* wheels
       - run: mv ./osx-3.8-wheel/* wheels
+      - run: mv ./osx-3.7-wheel/* wheels
       - run: mv ./windows-3.13-wheel/* wheels
       - run: mv ./windows-3.12-wheel/* wheels
       - run: mv ./windows-3.11-wheel/* wheels
       - run: mv ./windows-3.10-wheel/* wheels
       - run: mv ./windows-3.9-wheel/* wheels
       - run: mv ./windows-3.8-wheel/* wheels
+      - run: mv ./windows-3.7-wheel/* wheels
 
 
       - name: Publish a Python distribution to PyPI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,63 @@
+# 0.1.56
+
+- Upgrade to sqlparser-rs 0.56.0
+
+In v0.55 of sqlparser-rs, the `ObjectName` structure has been changed as shown below. Here is now to migrate.
+
+```diff
+- pub struct ObjectName(pub Vec<Ident>);
++ pub struct ObjectName(pub Vec<ObjectNamePart>)
+```
+
+Therefore, when using the `parse_sql` function, the data structure of the table name in the return value will change.
+
+Previously:
+
+```json
+{
+    "value": "employee",
+    "quote_style": null,
+    "span":
+    {
+        "start":
+        {
+            "line": 4,
+            "column": 10
+        },
+        "end":
+        {
+            "line": 4,
+            "column": 18
+        }
+    }
+}
+```
+
+Now:
+
+
+```json
+{
+    "Identifier":
+    {
+        "value": "employee",
+        "quote_style": null,
+        "span":
+        {
+            "start":
+            {
+                "line": 4,
+                "column": 10
+            },
+            "end":
+            {
+                "line": 4,
+                "column": 18
+            }
+        }
+    }
+}
+```
 
 # 0.1.36
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqloxide"
-version = "0.1.54"
+version = "0.1.56"
 authors = ["Will Eaton <me@wseaton.com>"]
 edition = "2021"
 
@@ -17,5 +17,5 @@ version = "0.22"
 features = ["extension-module"]
 
 [dependencies.sqlparser]
-version = "0.54.0"
+version = "0.56.0"
 features = ["serde", "visitor"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sqloxide"
-version = "0.1.54rc2"
+version = "0.1.56"
 authors = [{ name = "Will Eaton", email= "<me@wseaton.com>" }]
 repository = "https://github.com/wseaton/sqloxide"
 license = "MIT"

--- a/tests/test_sqloxide.py
+++ b/tests/test_sqloxide.py
@@ -43,8 +43,14 @@ def test_extract_relations():
     ast = parse_sql(sql=SQL, dialect="ansi")
 
     assert extract_relations(parsed_query=ast)[0][0] == {
-        "value": "employee",
-        "quote_style": None,
+        "Identifier": {
+            "value": "employee",
+            "quote_style": None,
+            "span": {
+                "start": {"line": 4, "column": 10},
+                "end": {"line": 4, "column": 18},
+            },
+        }
     }
 
 
@@ -54,7 +60,7 @@ def test_mutate_relations():
 
     ast = parse_sql(sql=SQL, dialect="ansi")
     assert mutate_relations(parsed_query=ast, func=func) == [
-        'SELECT employee.first_name, employee.last_name, c.start_time, c.end_time, call_outcome.outcome_text FROM employee JOIN "call2"."call2"."call2" AS c ON c.employee_id = employee.id JOIN call2_outcome ON c.call_outcome_id = call_outcome.id ORDER BY c.start_time ASC'
+        'SELECT employee.first_name, employee.last_name, c.start_time, c.end_time, call_outcome.outcome_text FROM employee INNER JOIN "call2"."call2"."call2" AS c ON c.employee_id = employee.id INNER JOIN call2_outcome ON c.call_outcome_id = call_outcome.id ORDER BY c.start_time ASC'
     ]
 
 
@@ -81,7 +87,7 @@ def test_mutate_expressions():
     ast = parse_sql(sql=SQL, dialect="ansi")
     result = mutate_expressions(parsed_query=ast, func=func)
     assert result == [
-        'SELECT EMPLOYEE.FIRST_NAME, EMPLOYEE.LAST_NAME, C.START_TIME, C.END_TIME, CALL_OUTCOME.OUTCOME_TEXT FROM employee JOIN "call"."call"."call" AS c ON C.EMPLOYEE_ID = EMPLOYEE.ID JOIN call_outcome ON C.CALL_OUTCOME_ID = CALL_OUTCOME.ID ORDER BY C.START_TIME ASC'
+        'SELECT EMPLOYEE.FIRST_NAME, EMPLOYEE.LAST_NAME, C.START_TIME, C.END_TIME, CALL_OUTCOME.OUTCOME_TEXT FROM employee INNER JOIN "call"."call"."call" AS c ON C.EMPLOYEE_ID = EMPLOYEE.ID INNER JOIN call_outcome ON C.CALL_OUTCOME_ID = CALL_OUTCOME.ID ORDER BY C.START_TIME ASC'
     ]
 
 
@@ -93,7 +99,21 @@ def test_extract_expressions():
 
     assert exprs[0] == {
         "CompoundIdentifier": [
-            {"value": "employee", "quote_style": None},
-            {"value": "first_name", "quote_style": None},
+            {
+                "value": "employee",
+                "quote_style": None,
+                "span": {
+                    "end": {"column": 20, "line": 2},
+                    "start": {"column": 12, "line": 2},
+                },
+            },
+            {
+                "value": "first_name",
+                "quote_style": None,
+                "span": {
+                    "end": {"column": 31, "line": 2},
+                    "start": {"column": 21, "line": 2},
+                },
+            },
         ]
     }


### PR DESCRIPTION
According to statistics, Python 3.7's current usage share still exceeds 20%. Since sqloxide itself supports Python 3.7, we hope to ensure support for it when building wheels.